### PR TITLE
dont return empty values from parser

### DIFF
--- a/src/hashicorp-aws/ec2.ts
+++ b/src/hashicorp-aws/ec2.ts
@@ -1,5 +1,6 @@
 import { TfDiff, Json, TxtFile, JsonFile } from '@tinystacks/precloud';
 import { getTfEntry, resolveValue } from './helpers';
+import { dontReturnEmpty } from '../utils';
 
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Address.html
 function parseEip (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: JsonFile[]): Json {
@@ -12,7 +13,7 @@ function parseEip (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: Json
   const publicIpv4Pool = resolveValue(diff, tfPlan, tfEntry, 'public_ipv4_pool');
   const tagSet = resolveValue(diff, tfPlan, tfEntry, 'tags');
 
-  return {
+  const properties = {
     domain,
     instanceId,
     customerOwnedIpv4Pool,
@@ -21,6 +22,8 @@ function parseEip (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: Json
     publicIpv4Pool,
     tagSet
   };
+
+  return dontReturnEmpty(properties);
 }
 
 export {

--- a/src/hashicorp-aws/s3.ts
+++ b/src/hashicorp-aws/s3.ts
@@ -1,5 +1,6 @@
 import { TfDiff, Json, TxtFile, JsonFile } from '@tinystacks/precloud';
 import { getTfEntry, resolveValue } from './helpers';
+import { dontReturnEmpty } from '../utils';
 
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Bucket.html
 export function parseS3Bucket (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: JsonFile[]): Json {
@@ -7,10 +8,11 @@ export function parseS3Bucket (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], 
   const name = resolveValue(diff, tfPlan, tfEntry, 'bucket');
   const tags = resolveValue(diff, tfPlan, tfEntry, 'tags');
   const tagSet = Object.entries(tags || {}).map(s3TagMapper);
-  return {
+  const properties = {
     Name: name,
     TagSet: tagSet
   };
+  return dontReturnEmpty(properties);
 }
 
 export function s3TagMapper (list: any[]) {

--- a/src/hashicorp-aws/sqs.ts
+++ b/src/hashicorp-aws/sqs.ts
@@ -1,5 +1,6 @@
 import { TfDiff, Json, TxtFile, JsonFile } from '@tinystacks/precloud';
 import { getTfEntry, resolveValue } from './helpers';
+import { dontReturnEmpty } from '../utils';
 
 // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html
 function parseSqsQueue (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: JsonFile[]): Json {
@@ -11,11 +12,12 @@ function parseSqsQueue (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson:
       .filter(([propertyName]) => propertyName !== 'name' && propertyName !== 'tags')
       .map(([propertyName]) => [propertyName, resolveValue(diff, tfPlan, tfEntry, propertyName)])
   );
-  return {
+  const properties = {
     QueueName: queueName,
     Tags: tags,
     Attributes: attributes
   };
+  return dontReturnEmpty(properties);
 }
 
 export {

--- a/src/hashicorp-aws/vpc.ts
+++ b/src/hashicorp-aws/vpc.ts
@@ -1,5 +1,6 @@
 import { TfDiff, Json, TxtFile, JsonFile, TerraformTypes } from '@tinystacks/precloud';
 import { getTfEntry, resolveValue } from './helpers';
+import { dontReturnEmpty } from '../utils';
 
 const {
   TF_ROUTE_TABLE_ASSOCIATION,
@@ -24,12 +25,14 @@ function parseVpc (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: Json
   }
   const tagSet = tfEntry?.tags;
 
-  return {
+  const properties = {
     cidrBlock,
     instanceTenancy,
     ipv6CidrBlockAssociationSet,
     tagSet
   };
+
+  return dontReturnEmpty(properties);
 }
 
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NatGateway.html
@@ -39,11 +42,13 @@ function parseNatGateway (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJso
   const subnetId = resolveValue(diff, tfPlan, tfEntry, 'subnet_id');
   const tagSet = resolveValue(diff, tfPlan, tfEntry, 'tags');
 
-  return {
+  const properties = {
     connectivityType,
     subnetId,
     tagSet
   };
+
+  return dontReturnEmpty(properties);
 }
 
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Subnet.html
@@ -82,7 +87,7 @@ function parseSubnet (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: J
   const vpcId = resolveValue(diff, tfPlan, tfEntry, 'vpc_id');
   const tagSet = resolveValue(diff, tfPlan, tfEntry, 'tags');
 
-  return {
+  const properties = {
     assignIpv6AddressOnCreation,
     availabilityZone,
     availabilityZoneId,
@@ -98,6 +103,8 @@ function parseSubnet (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: J
     vpcId,
     tagSet
   };
+  
+  return dontReturnEmpty(properties);
 }
 
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RouteTableAssociation.html
@@ -108,11 +115,12 @@ function parseRouteTableAssociation (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFi
   const routeTableId = resolveValue(diff, tfPlan, tfEntry, 'route_table_id');
   const subnetId = resolveValue(diff, tfPlan, tfEntry, 'subnet_id');
 
-  return {
+  const properties = {
     gatewayId,
     routeTableId,
     subnetId
   };
+  return dontReturnEmpty(properties);
 }
 
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Route.html
@@ -134,7 +142,7 @@ function parseRoute (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: Js
   const vpcPeeringConnectionId = resolveValue(diff, tfPlan, tfEntry, 'vpc_peering_connection_id');
   const vpcEndpointId = resolveValue(diff, tfPlan, tfEntry, 'vpc_endpoint_id');
 
-  return {
+  const properties = {
     carrierGatewayId,
     coreNetworkArn,
     destinationCidrBlock,
@@ -150,6 +158,8 @@ function parseRoute (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJson: Js
     vpcEndpointId,
     vpcPeeringConnectionId
   };
+
+  return dontReturnEmpty(properties);
 }
 
 interface TfJsonEntry {
@@ -186,11 +196,13 @@ function parseRouteTable (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJso
       const routeTableId = resolveValue(diff, tfPlan, entry.properties, 'route_table_id');
       const subnetId = resolveValue(diff, tfPlan, entry.properties, 'subnet_id');
 
-      return {
+      const properties = {
         gatewayId,
         routeTableId,
         subnetId
       };
+
+      return dontReturnEmpty(properties);
     });
 
   const routeSet = [];
@@ -212,7 +224,7 @@ function parseRouteTable (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJso
         const vpcPeeringConnectionId = resolveValue(diff, tfPlan, route, 'vpc_peering_connection_id');
         const vpcEndpointId = resolveValue(diff, tfPlan, route, 'vpc_endpoint_id');
 
-        return {
+        const properties = {
           carrierGatewayId,
           coreNetworkArn,
           destinationCidrBlock,
@@ -228,6 +240,8 @@ function parseRouteTable (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJso
           vpcEndpointId,
           vpcPeeringConnectionId
         };
+
+        return dontReturnEmpty(properties);
       })
     );
   } else {
@@ -252,7 +266,7 @@ function parseRouteTable (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJso
           const vpcPeeringConnectionId = resolveValue(diff, tfPlan, entry.properties, 'vpc_peering_connection_id');
           const vpcEndpointId = resolveValue(diff, tfPlan, entry.properties, 'vpc_endpoint_id');
 
-          return {
+          const properties = {
             carrierGatewayId,
             coreNetworkArn,
             destinationCidrBlock,
@@ -268,6 +282,8 @@ function parseRouteTable (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJso
             vpcEndpointId,
             vpcPeeringConnectionId
           };
+
+          return dontReturnEmpty(properties);
         })
     );
   }
@@ -276,12 +292,14 @@ function parseRouteTable (diff: TfDiff, tfPlan: Json, _tfFiles: TxtFile[], tfJso
   const tagSet = resolveValue(diff, tfPlan, tfEntry, 'tags');
   const vpcId = resolveValue(diff, tfPlan, tfEntry, 'vpc_id');
 
-  return {
+  const properties = {
     associationSet,
     routeSet,
     tagSet,
     vpcId
   };
+
+  return dontReturnEmpty(properties);
 }
 
 export {

--- a/src/utils/dont-return-empty.ts
+++ b/src/utils/dont-return-empty.ts
@@ -1,0 +1,16 @@
+import { Json } from '@tinystacks/precloud';
+import isNil from 'lodash.isnil';
+import isPlainObject from 'lodash.isplainobject';
+
+export function dontReturnEmpty (properties: Json): Json | undefined {
+  const values = Object.values(properties);
+  const objectIsEmpty = values.every((value) => {
+    if(isPlainObject(value)) {
+      return isNil(dontReturnEmpty(value));
+    } else if (Array.isArray(value)) {
+      return value.map(dontReturnEmpty).every(isNil);
+    }
+    return isNil(value);
+  });
+  return objectIsEmpty ? undefined : properties;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './dont-return-empty';

--- a/test/utils/dont-return-empty.test.ts
+++ b/test/utils/dont-return-empty.test.ts
@@ -1,0 +1,49 @@
+import { dontReturnEmpty } from '../../src/utils/dont-return-empty';
+
+describe('dontReturnEmpty', () => {
+  it('returns properties if any are defined', () => {
+    const input: any = {
+      a: 1,
+      b: undefined,
+      c: null,
+      d: {},
+      e: []
+    };
+
+    const output = dontReturnEmpty(input);
+
+    expect(output).toEqual(input);
+  });
+  it('returns undefined if all are empty', () => {
+    const input: any = {
+      a: undefined,
+      b: undefined,
+      c: null,
+      d: {},
+      e: []
+    };
+
+    const output = dontReturnEmpty(input);
+
+    expect(output).toEqual(undefined);
+  });
+  it('works on nested objects', () => {
+    const input: any = {
+      a: undefined,
+      b: undefined,
+      c: null,
+      d: {},
+      e: [],
+      f: {
+        g: [],
+        h: {},
+        i: [{}]
+      },
+      j: [{ k: [] }, []]
+    };
+
+    const output = dontReturnEmpty(input);
+
+    expect(output).toEqual(undefined);
+  });
+});


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix
 - [ ] Non-bug Patch (i.e. dependency update, cicd update, etc.)

## Link to Notion Task or Github Issue
<!-- Go to the task, press the ellipsis button (three dots), then click Copy Link -->
<!-- Example: -->
<!-- https://www.notion.so/tinystacks/Add-Linter-to-Templates-6b4b1910281842308c11d14961d01237 -->
N/A - testing

## Summary of Bug Fix(es)
### Previous Behaviour
_Description of the bug and it's impact_
Would return object with keys and undefined values, but should return undefined if unable to parse a resource.  No defined values intrinsically means a failed parse.

### New Behaviour
_Description of the bug fix and it's impact_
Now returns undefined if all values are empty.